### PR TITLE
Fix size passed to hal_malloc in example code

### DIFF
--- a/linuxcnc-hal-sys/README.md
+++ b/linuxcnc-hal-sys/README.md
@@ -47,7 +47,7 @@ unsafe {
 
     let signals = Signals::new(&[signal_hook::SIGTERM, signal_hook::SIGINT]).unwrap();
 
-    let storage = hal_malloc(mem::size_of::<f64>() as i64) as *mut *mut f64;
+    let storage = hal_malloc(mem::size_of::<*mut f64>() as i64) as *mut *mut f64;
 
     if storage.is_null() {
         panic!("Failed to allocate storage");

--- a/linuxcnc-hal-sys/src/lib.rs
+++ b/linuxcnc-hal-sys/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //!     let signals = Signals::new(&[signal_hook::SIGTERM, signal_hook::SIGINT]).unwrap();
 //!
-//!     let storage = hal_malloc(mem::size_of::<f64>() as i64) as *mut *mut f64;
+//!     let storage = hal_malloc(mem::size_of::<*mut f64>() as i64) as *mut *mut f64;
 //!
 //!     println!("Storage {:?}", storage);
 //!


### PR DESCRIPTION
We need to allocate space for a pointer, not a double. On 32-bit platforms, the old code would request more space than needed.  (This might be harmless in practice, but it made the code a little confusing.)